### PR TITLE
fix: higress-controller recreate many times

### DIFF
--- a/internal/controller/higresscontroller/service.go
+++ b/internal/controller/higresscontroller/service.go
@@ -58,13 +58,21 @@ func updateServiceSpec(svc *apiv1.Service, instance *operatorv1alpha1.HigressCon
 				Port:     15014,
 			},
 		}
-		svc.Spec.Ports = append(svc.Spec.Ports, ports...)
+		set := make(map[string]struct{})
+		for _, port := range svc.Spec.Ports {
+			set[port.Name] = struct{}{}
+		}
+		for _, port := range ports {
+			if _, ok := set[port.Name]; !ok {
+				svc.Spec.Ports = append(svc.Spec.Ports, port)
+			}
+		}
 	}
 }
 
 func muteService(svc *apiv1.Service, instance *operatorv1alpha1.HigressController) controllerutil.MutateFn {
 	return func() error {
-		initService(svc, instance)
+		updateServiceSpec(svc, instance)
 		return nil
 	}
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -31,4 +34,52 @@ func CreateIfNotExits(ctx context.Context, cli client.Client, object client.Obje
 	}
 
 	return false, err
+}
+
+func createOrUpdate(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn, logger logr.Logger) (controllerutil.OperationResult, error) {
+	key := client.ObjectKeyFromObject(obj)
+	if err := c.Get(ctx, key, obj); err != nil {
+		if !errors.IsNotFound(err) {
+			return controllerutil.OperationResultNone, err
+		}
+		if err := mutate(f, key, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+		return controllerutil.OperationResultCreated, nil
+	}
+
+	existing := obj.DeepCopyObject()
+	if err := mutate(f, key, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	if equality.Semantic.DeepEqual(existing, obj) {
+		return controllerutil.OperationResultNone, nil
+	}
+
+	logger.Info(fmt.Sprintf("the diff of %v is %v", key, cmp.Diff(obj, existing)))
+
+	if err := c.Update(ctx, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	return controllerutil.OperationResultUpdated, nil
+}
+
+func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) error {
+	if err := f(); err != nil {
+		return err
+	}
+	if newKey := client.ObjectKeyFromObject(obj); key != newKey {
+		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
+	}
+	return nil
+}
+
+func UpdateObjectMeta(obj *metav1.ObjectMeta, instance metav1.Object, labels map[string]string) {
+	obj.Name = instance.GetName()
+	obj.Namespace = instance.GetNamespace()
+	obj.Labels = labels
 }


### PR DESCRIPTION
### Background

When the operator creates higress-controller && higress-gateway,  higress-controller has been recreating and will take a long time to become avaliable

### Analysis
From the console log, we can see that the reconciler keeps recreates the higress-controller deployment because it detects that the expected value is different from the actual value, but why?

Each time we CreateOrUpdate the Deployment, we override the default values k8s gives to the deployment, e.g
```
- Replicas: &1,
+ Replicas: nil,
```
### Conclusion

We shouldn't override those defaults, but the code would be ugly after this change

We should refactor this code later using `relect`
